### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "massive": "^5.11.0",
-    "npm": "^6.9.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.0",


### PR DESCRIPTION

Hello AutoDave91!

It seems like you have npm as one of your (dev-) dependency in Harrys-List.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
